### PR TITLE
More descriptive error for debugger

### DIFF
--- a/DenotativeObject.pck.st
+++ b/DenotativeObject.pck.st
@@ -1693,7 +1693,7 @@ debug: aCompiledMethod receiver: anObject in: evalContext
 	debugger openFullNoSuspendLabel: 'Debug it'.
 
 	[ [debugger originalSend.
-	(debugger receiver is: #DenotativeObject)] on: Exception do: [ :anException | self inform: 'Can not debug this'. ^self ] ] whileFalse.
+	(debugger receiver is: #DenotativeObject)] on: Exception do: [ :anException | self inform: 'Cannot debug a message to something that isn't a DenotativeObject.'. ^self ] ] whileFalse.
 
 	! !
 


### PR DESCRIPTION
When the message that is being debugged is not sent to a DenotativeObject, the Editor shows a 'Can not debug' message, which is a little unhelpful. This commit changes to the minimally more helpful 'Cannot debug a message to something that isn't a DenotativeObject.'.